### PR TITLE
Initialize _file property in Zend_Validate_File_Count

### DIFF
--- a/src/Zend/Validate/File/Count.php
+++ b/src/Zend/Validate/File/Count.php
@@ -82,7 +82,7 @@ class Zend_Validate_File_Count extends Zend_Validate_Abstract
      * Internal file array
      * @var array
      */
-    protected $_files;
+    protected $_files = array();
 
     /**
      * Sets validator options


### PR DESCRIPTION
Zend calls `count()` on an unitialized array property which triggers an error since PHP 7.2. I pre-initialize this property as empty array, so the count() validation won't fail with an hard error

See:
* https://3v4l.org/hjSZr (Executed `count(null);` with different PHP versions)
* https://github.com/diablomedia/zf1-validate-file/blob/96fef17afd8fa36bf4190b7e531b0f74c36f6217/src/Zend/Validate/File/Count.php#L85 (The unitialized property)
* https://github.com/diablomedia/zf1-validate-file/blob/96fef17afd8fa36bf4190b7e531b0f74c36f6217/src/Zend/Validate/File/Count.php#L247 (The count() call)